### PR TITLE
Subscription handling

### DIFF
--- a/CocoaUPnP/Events/UPPEventSubscription.h
+++ b/CocoaUPnP/Events/UPPEventSubscription.h
@@ -74,7 +74,19 @@
 ///-----------------------------------------------------------------------------
 
 /**
- Convenience initialiser which returns a new subscription object.
+ Convenience initialiser which returns a new subscription object when passed in
+ an event subscription URL.
+
+ @param eventSubscriptionURL The full event subscription URL, which is used when
+ resubscribing or unsubscribing from events.
+
+ @return Returns a new subscription object.
+ */
++ (instancetype)subscriptionWithSubscriptionURL:(NSURL *)eventSubscriptionURL;
+
+/**
+ Convenience initialiser which returns a new subscription object when given a
+ subscription identifier, an expiry date and an event subscription URL.
 
  @param subscriptionID       The subscription identifier returned by the service.
  @param expiryDate           The date at which the subscription is expired by the

--- a/CocoaUPnP/Events/UPPEventSubscription.m
+++ b/CocoaUPnP/Events/UPPEventSubscription.m
@@ -17,6 +17,13 @@
 
 #pragma mark - Initialisation
 
++ (instancetype)subscriptionWithSubscriptionURL:(NSURL *)eventSubscriptionURL
+{
+    return [[[self class] alloc] initWithSubscriptionID:nil
+                                             expiryDate:nil
+                                   eventSubscriptionURL:eventSubscriptionURL];
+}
+
 + (instancetype)subscriptionWithID:(NSString *)subscriptionID expiryDate:(NSDate *)expiryDate eventSubscriptionURL:(NSURL *)eventSubscriptionURL
 {
     return [[[self class] alloc] initWithSubscriptionID:subscriptionID

--- a/CocoaUPnP/Events/UPPEventSubscriptionManager.h
+++ b/CocoaUPnP/Events/UPPEventSubscriptionManager.h
@@ -41,7 +41,7 @@
  @param completion A block to run when the subscription call finishes. Returns a
  BOOL corresponding to wether the call succeeded or failed.
  */
-- (void)subscribeObserver:(id<UPPEventSubscriptionDelegate>)observer toService:(UPPBasicService *)service completion:(void(^)(BOOL success))completion;
+- (void)subscribeObserver:(id<UPPEventSubscriptionDelegate>)observer toService:(UPPBasicService *)service completion:(void(^)(UPPEventSubscription *subscription, NSError *error))completion;
 
 /**
  Renew a current subscription.

--- a/CocoaUPnP/Events/UPPEventSubscriptionManager.m
+++ b/CocoaUPnP/Events/UPPEventSubscriptionManager.m
@@ -79,23 +79,46 @@
 
 #pragma mark - Public Methods
 
-- (void)subscribeObserver:(id<UPPEventSubscriptionDelegate>)observer toService:(UPPBasicService *)service completion:(void(^)(BOOL success))completion;
+- (void)subscribeObserver:(id<UPPEventSubscriptionDelegate>)observer toService:(UPPBasicService *)service completion:(void(^)(UPPEventSubscription *subscription, NSError *error))completion
 {
     if (![self.eventServer isRunning]) {
         self.eventServer.eventDelegate = self;
         [self.eventServer startServer];
     }
 
-    UPPEventSubscription *subscripton = [self subscriptionWithURL:service.eventSubscriptionURL];
-    if (subscripton) {
-        [subscripton addEventObserver:observer];
+    // If we already have an existing subscription, add the new observer then
+    // bail out early.
+    UPPEventSubscription *subscription = [self subscriptionWithURL:service.eventSubscriptionURL];
+    if (subscription) {
+        [subscription addEventObserver:observer];
         if (completion) {
-            completion(YES); // This probably should return an error when NO
+            completion(subscription, nil);
         }
         return;
     }
 
+    // Create a new subscription.
     NSURL *url = service.eventSubscriptionURL;
+    subscription = [UPPEventSubscription subscriptionWithSubscriptionURL:url];
+    [self subscribe:subscription completion:^(NSString *subscriptionID, NSDate *expiryDate, NSError *error) {
+        if (error) {
+            if (completion) {
+                completion(nil, error);
+            }
+            return;
+        }
+        [subscription updateSubscriptionID:subscriptionID expiryDate:expiryDate];
+        [subscription addEventObserver:observer];
+        [self.activeSubscriptions addObject:subscription];
+        if (completion) {
+            completion(subscription, nil);
+        }
+    }];
+}
+
+- (void)subscribe:(UPPEventSubscription *)subscription completion:(void(^)(NSString *subscriptionID, NSDate *expiryDate, NSError *error))completion
+{
+    NSURL *url = subscription.eventSubscriptionURL;
     NSURLRequest *request = [self subscriptionRequestWithEventSubscriptionURL:url];
 
     [self sendSubscriptionRequest:request completion:^(NSURLResponse *response, NSError *error) {
@@ -105,26 +128,25 @@
             if (self.activeSubscriptions.count == 0) {
                 [self.eventServer stopServer];
             }
-            if (completion) {
-                completion(NO);
-            }
+            completion(nil, nil, error);
             return;
-        }
-
-        NSDictionary *headers = [(NSHTTPURLResponse *)response allHeaderFields];
-        UPPEventSubscription *subscription;
-        subscription = [self subscriptionWithURL:url
-                                         headers:headers
-                                        observer:observer];
-        [self.activeSubscriptions addObject:subscription];
-        if (completion) {
-            completion(YES);
+        } else {
+            NSDictionary *headers = [(NSHTTPURLResponse *)response allHeaderFields];
+            NSString *subId = headers[@"SID"];
+            NSDate *expiry = [self dateFromHeader:headers[@"TIMEOUT"]];
+            completion(subId, expiry, nil);
         }
     }];
 }
 
-- (void)renewSubscription:(UPPEventSubscription *)subscription completion:(void(^)(NSString *subscriptionID, NSDate *expiryDate, NSError *error))completion;
+- (void)renewSubscription:(UPPEventSubscription *)subscription completion:(void(^)(NSString *subscriptionID, NSDate *expiryDate, NSError *error))completion
 {
+    if (!subscription.subscriptionID) {
+        [self subscribe:subscription completion:^(NSString *subscriptionID, NSDate *expiryDate, NSError *error) {
+            [subscription updateSubscriptionID:subscriptionID expiryDate:expiryDate];
+        }];
+        return;
+    }
     NSURL *subscriptionURL = subscription.eventSubscriptionURL;
 
     NSDictionary *headers = @{ @"HOST": [subscriptionURL absoluteString],

--- a/CocoaUPnP/Events/UPPEventSubscriptionManager.m
+++ b/CocoaUPnP/Events/UPPEventSubscriptionManager.m
@@ -181,23 +181,7 @@
 
 - (void)subscriptionExpired:(UPPEventSubscription *)subscription completion:(void(^)(NSString *subscriptionID, NSDate *expiryDate, NSError *error))completion
 {
-    NSURL *url = subscription.eventSubscriptionURL;
-    NSURLRequest *request = [self subscriptionRequestWithEventSubscriptionURL:url];
-
-    [self sendSubscriptionRequest:request completion:^(NSURLResponse *response, NSError *error) {
-        NSInteger code = [(NSHTTPURLResponse *)response statusCode];
-
-        if (code != 200) {
-            NSError *e = error ?: UPPErrorWithCodeAndDescription(code, @"Event subscription error");
-            completion(nil, nil, e);
-            return;
-        }
-        NSDictionary *headers = [(NSHTTPURLResponse *)response allHeaderFields];
-        NSString *subscriptionID = headers[@"SID"];
-        NSDate *expiryDate = [self dateFromHeader:headers[@"TIMEOUT"]];
-
-        completion(subscriptionID, expiryDate, nil);
-    }];
+    [self subscribe:subscription completion:completion];
 }
 
 - (NSURLRequest *)subscriptionRequestWithEventSubscriptionURL:(NSURL *)url

--- a/CocoaUPnPTests/Events/UPPEventSubscriptionSpec.m
+++ b/CocoaUPnPTests/Events/UPPEventSubscriptionSpec.m
@@ -36,6 +36,13 @@ describe(@"UPPEventSubscription", ^{
         expect([sut eventSubscriptionURL]).to.equal(subscriptionURL);
     });
 
+    it(@"should have a basic initialiser", ^{
+        sut = [UPPEventSubscription subscriptionWithSubscriptionURL:subscriptionURL];
+        expect([sut subscriptionID]).to.beNil();
+        expect([sut expiryDate]).to.beNil();
+        expect([sut eventSubscriptionURL]).to.equal(subscriptionURL);
+    });
+
     describe(@"when storing observers", ^{
 
         __block id mockObserver;


### PR DESCRIPTION
I have seen a couple of crashes where the library attempts to insert nil into a dictionary due to lack of sanity checking during re-subscription.

This patch tightens up the two flows (resubscribe, and subscription expired) to make handling more robust.
