### PR TITLE
Remove travis workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: objective-c
 podfile: Example/Podfile
-before_install:
-  # https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone SE (10" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
-  - echo $IOS_SIMULATOR_UDID
-  - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
-before_script:
-  - rvm get head || true # https://github.com/travis-ci/travis-ci/issues/6307
 script: 
   - travis_retry scan --device 'iPhone SE'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ podfile: Example/Podfile
 before_install:
   - pod repo update
 script: 
-  - travis_retry scan --device 'iPhone SE'
+  - travis_retry fastlane scan --device 'iPhone SE'
 after_success:
   - bundle exec slather
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: objective-c
 podfile: Example/Podfile
+before_install:
+  - pod repo update
 script: 
   - travis_retry scan --device 'iPhone SE'
 after_success:

--- a/CocoaUPnP.podspec
+++ b/CocoaUPnP.podspec
@@ -23,8 +23,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig     = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
 
-  s.dependency 'CocoaAsyncSocket', '~> 7'
-  s.dependency 'Ono', '~> 2'
-  s.dependency 'AFNetworking', '~> 3'
-  s.dependency 'GCDWebServer', '~> 3'
+  s.dependency 'CocoaAsyncSocket', '~> 7.6.3'
+  s.dependency 'Ono', '~> 2.1.1'
+  s.dependency 'AFNetworking', '~> 3.2.1'
+  s.dependency 'GCDWebServer', '~> 3.5.2'
 end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,10 +6,10 @@ target 'Example' do
 end
 
 target 'ExampleTests' do
-  pod 'Specta', '~> 1'
-  pod 'Expecta', '~> 1'
-  pod 'OCMock', '~> 3'
-  pod 'OHHTTPStubs', '~> 6'
+  pod 'Specta', '~> 1.0.7'
+  pod 'Expecta', '~> 1.0.6'
+  pod 'OCMock', '~> 3.4.3'
+  pod 'OHHTTPStubs', '~> 6.1.0'
 end
 
 # Xcode 10 generates a bunch of warnings when using CocoaPods

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -16,10 +16,10 @@ PODS:
     - AFNetworking/NSURLSession
   - CocoaAsyncSocket (7.6.3)
   - CocoaUPnP (1.0.0):
-    - AFNetworking (~> 3)
-    - CocoaAsyncSocket (~> 7)
-    - GCDWebServer (~> 3)
-    - Ono (~> 2)
+    - AFNetworking (~> 3.2.1)
+    - CocoaAsyncSocket (~> 7.6.3)
+    - GCDWebServer (~> 3.5.2)
+    - Ono (~> 2.1.1)
   - Expecta (1.0.6)
   - GCDWebServer (3.5.2):
     - GCDWebServer/Core (= 3.5.2)
@@ -43,10 +43,10 @@ PODS:
 
 DEPENDENCIES:
   - CocoaUPnP (from `../CocoaUPnP.podspec`)
-  - Expecta (~> 1)
-  - OCMock (~> 3)
-  - OHHTTPStubs (~> 6)
-  - Specta (~> 1)
+  - Expecta (~> 1.0.6)
+  - OCMock (~> 3.4.3)
+  - OHHTTPStubs (~> 6.1.0)
+  - Specta (~> 1.0.7)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -66,7 +66,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
-  CocoaUPnP: 91a2c7c5d9ce41921a6a6f25cc0c749019c2f350
+  CocoaUPnP: 7120f4f44ef8194b959c3f98cfa1bb993dc0b54e
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   GCDWebServer: ead88cd14596dd4eae4f5830b8877c87c8728990
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
@@ -74,6 +74,6 @@ SPEC CHECKSUMS:
   Ono: 13c25831a4a66b30df93bd1fa57cf70f13c62699
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
-PODFILE CHECKSUM: 49d9de033e0ab5f96033945b596ffee91831432d
+PODFILE CHECKSUM: a84edd7882244a628567d6397a85e96593bd894f
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,10 +21,10 @@ PODS:
     - GCDWebServer (~> 3)
     - Ono (~> 2)
   - Expecta (1.0.6)
-  - GCDWebServer (3.4.2):
-    - GCDWebServer/Core (= 3.4.2)
-  - GCDWebServer/Core (3.4.2)
-  - OCMock (3.4.2)
+  - GCDWebServer (3.5.2):
+    - GCDWebServer/Core (= 3.5.2)
+  - GCDWebServer/Core (3.5.2)
+  - OCMock (3.4.3)
   - OHHTTPStubs (6.1.0):
     - OHHTTPStubs/Default (= 6.1.0)
   - OHHTTPStubs/Core (6.1.0)
@@ -68,12 +68,12 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
   CocoaUPnP: 91a2c7c5d9ce41921a6a6f25cc0c749019c2f350
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  GCDWebServer: 8d67ee9f634b4bb91eb4b8aee440318a5fc6debd
-  OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
+  GCDWebServer: ead88cd14596dd4eae4f5830b8877c87c8728990
+  OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Ono: 13c25831a4a66b30df93bd1fa57cf70f13c62699
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
-PODFILE CHECKSUM: bcd01bb91fa2e17acc88c1b09d56c450e862a115
+PODFILE CHECKSUM: 49d9de033e0ab5f96033945b596ffee91831432d
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Theres a few workarounds in `.travis.yml` that used to be required. This pull request removes them.